### PR TITLE
Negotiate MSCHAPv2 when an EAP challenge is received

### DIFF
--- a/EAPPacket.py
+++ b/EAPPacket.py
@@ -103,8 +103,7 @@ class EAPPacket:
     @staticmethod
     def legacyNak(identifiier=None):
         """
-        Get the bytes of a EAP packet with the code RESPONSE, the type EAP_MS_AUTH, the provided MSCHAP packet data and
-        identifier.
+        Get the bytes of a EAP packet with the code RESPONSE, the type NAK, requesting MSCHAP with identifier.
 
         :param identifiier: the identifier
         :type identifiier: int|None

--- a/EAPPacket.py
+++ b/EAPPacket.py
@@ -100,6 +100,25 @@ class EAPPacket:
 
         return packet.__bytes__()
 
+    @staticmethod
+    def legacyNak(identifiier=None):
+        """
+        Get the bytes of a EAP packet with the code RESPONSE, the type EAP_MS_AUTH, the provided MSCHAP packet data and
+        identifier.
+
+        :param identifiier: the identifier
+        :type identifiier: int|None
+        :return: the packet bytes data
+        :rtype: bytes
+        """
+
+        packet = EAPPacket()
+        packet.set_id(identifiier)
+        packet.code = EAPPacket.CODE_RESPONSE
+        packet.type = EAPPacket.TYPE_NAK
+        packet.data = bytearray([EAPPacket.TYPE_EAP_MS_AUTH])
+
+        return packet.__bytes__()
 
     @staticmethod
     def mschapv2(mschapv2_packet, identifiier=None):

--- a/RADIUS.py
+++ b/RADIUS.py
@@ -464,6 +464,9 @@ class RADIUS:
             if response_eap.code != EAPPacket.CODE_REQUEST:
                 raise ValueError('Stage 1 : the server doesn\'t respond as expected')
 
+        if response_eap.type != EAPPacket.TYPE_EAP_MS_AUTH:
+            raise ValueError('Stage 1 : the server doesn\'t respond as expected')
+
         response_eap_mschap2 = MSCHAPv2Packet.from_bytes(response_eap.data)
 
         if response_eap_mschap2.opcode != MSCHAPv2Packet.OPCODE_CHALLENGE:

--- a/RADIUS.py
+++ b/RADIUS.py
@@ -448,12 +448,26 @@ class RADIUS:
         if response_eap.code != EAPPacket.CODE_REQUEST:
             raise ValueError('Stage 1 : the server doesn\'t respond as expected')
 
+        state = response_packet.get_raw_attribute(24)
+
+        if response_eap.type == EAPPacket.TYPE_MD5_CHALLENGE:
+            state = response_packet.get_raw_attribute(24)
+            packet_to_send = RADIUSPacket(RADIUSPacket.TYPE_ACCESS_REQUEST, self.authenticator)
+            packet_to_send.set_attribute(1, username)
+            packet_to_send.set_raw_attribute(24, state)
+            packet_to_send.set_attribute(79, EAPPacket.legacyNak(response_eap.id))
+            packet_to_send.set_include_message_authenticator()
+            response_packet = self._send_and_read(packet_to_send)
+            state = response_packet.get_raw_attribute(24)
+
+            response_eap = EAPPacket.from_bytes(response_packet.get_raw_attribute(79)[2:])
+            if response_eap.code != EAPPacket.CODE_REQUEST:
+                raise ValueError('Stage 1 : the server doesn\'t respond as expected')
+
         response_eap_mschap2 = MSCHAPv2Packet.from_bytes(response_eap.data)
 
         if response_eap_mschap2.opcode != MSCHAPv2Packet.OPCODE_CHALLENGE:
             raise ValueError('Stage 1 : the server doesn\'t respond as expected')
-
-        state = response_packet.get_raw_attribute(24)
 
         # Generate a new peer challenge
         peer_challenge = self._generate_random_bytes(16)


### PR DESCRIPTION
This handles the situation where multiple versions of MSCHAP (v1 & v2) or other alternatives to MSCHAP are supported over the same RADIUS server using EAP.

In this case, instead of directly getting a EAP-MS-AUTH back, an EAP-MD5-CHALLENGE is received and it must be responded with a NAK, indicating the desire to use MSCHAPv2, as suggested in https://datatracker.ietf.org/doc/html/rfc3748#section-5.4:
> The Request contains a "challenge" message to the peer.  A Response MUST be sent in reply to the Request.  The Response MAY be either of Type 4 (MD5-Challenge), Nak (Type 3), or Expanded Nak (Type 254).  The Nak reply indicates the peer's desired authentication Type(s).

This change should be backwards compatible, since only a EAP-MD5-CHALLENGE response will trigger the new code.

The move to obtain the state info ahead of processing the packet should not make a difference for the previous uses of the code, but it is required to send the NAK as well as to adjust the state for following packets.

The code also introduces an additional check for the EAP-MS-AUTH type on the received packet. Without this check, the user may receive a misleading `Unknown opcode` error from [MSCHAPv2.py](https://github.com/mneitsabes/RADIUS-EAP-MSCHAPv2-Python-client/blob/cccabab25911247df2aa3e893f600663a3d65ebe/MSCHAPv2.py#L43) if the response is anything other than EAP-MS-AUTH.
That because the logic used to blindly try to parse MSCHAP content where there was none. This extra check is not expected to cause incompatibility issues.

A non EAP-MS-AUTH response situation described above may still happen, even with the additional code to send NAK, if the RADIUS server really does not support MSCHAP.
In which case a second EAP-MD5-CHALLENGE may be received, indicate the requested protocol is not supported.

A plain reject is also possible, but that situation is already covered by the check for `EAPPacket.CODE_REQUEST`.