### PR TITLE
(Legacy) MSCHAPv2 Support

### DIFF
--- a/MSCHAPv2.py
+++ b/MSCHAPv2.py
@@ -5,6 +5,84 @@ import binascii
 from Crypto.Hash import MD4
 from Crypto.Cipher import DES
 
+class VendorSpecificPacket:
+    """
+    Vendor Specific Packet
+    """
+
+    """
+    Microsoft Vendor Code
+    """
+    VENDOR_MICROSOFT = 311
+
+    """
+    MSCHAPv2 Challenge type
+    """
+    TYPE_MSCHAP_CHALLENGE = 11
+
+    """
+    MSCHAPv2 Challenge Response type
+    """
+    TYPE_MSCHAP_RESPONSE = 25
+
+    def __init__(self, vendor, type, value):
+        """
+
+        :param vendor: the vendor code
+        :type vendor: int
+        :param type: the type code
+        :type type: int
+        :param value: the value
+        :type value: bytes
+        """
+        self.vendor = vendor
+        self.type = type
+        self.value = value
+
+    def __bytes__(self):
+        """
+        Returns the bytes representation of the packet
+
+        :return: the bytes
+        :rtype: bytes
+        """
+        packet = bytearray()
+        packet += b'\x00\x00'  # for the vendor
+        packet += struct.pack('>H', self.vendor)
+        packet += struct.pack('B', self.type)
+        packet += struct.pack('B', len(self.value) + 2)
+        packet += self.value
+        return packet
+
+class MSCHAPv2Response:
+    """
+    MSCHAPv2 (legacy) response
+    """
+
+    def __init__(self, challenge, response):
+        """
+
+        :param challenge: the peer challenge
+        :type challenge: bytes
+        :param response: the challenge response
+        :type response: bytes
+        """        
+        self.challenge = challenge
+        self.response = response
+
+    def __bytes__(self):
+        """
+        Returns the bytes representation of the response
+
+        :return: the bytes
+        :rtype: bytes
+        """
+        packet = bytearray()
+        packet += b'\x00' * 2
+        packet += self.challenge
+        packet += b'\x00' * 8
+        packet += self.response
+        return packet
 
 class MSCHAPv2Packet:
     """
@@ -338,3 +416,4 @@ class MSCHAPv2Crypto:
             key += struct.pack('B', odd_parity[i])
 
         return key
+    

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A pure Python 3 RADIUS EAP-MSCHAPv2 and MSCHAPv2 client implementation.
 This project was developped because no RADIUS client library supports EAP-MSCHAPv2 (A ticket is open for the pyrad 
 library, see [here](https://github.com/pyradius/pyrad/issues/40)).
 
-This library **only supports** EAP-MSCHAPv2 and (legacy MSCHAPv2). This code has been tested with Microsoft Windows 
+This library **only supports** EAP-MSCHAPv2 and (legacy) MSCHAPv2. This code has been tested with Microsoft Windows 
 Server 2016 Network Policy Server and FreeRADIUS 3.0.25.
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# RADIUS EAP-MSCHAPv2 Client
+# RADIUS EAP-MSCHAPv2 and MSCHAPv2 Client
 
-A pure Python 3 RADIUS EAP-MSCHAPv2 client implementation.
+A pure Python 3 RADIUS EAP-MSCHAPv2 and MSCHAPv2 client implementation.
 
 # Explanation
 
 This project was developped because no RADIUS client library supports EAP-MSCHAPv2 (A ticket is open for the pyrad 
 library, see [here](https://github.com/pyradius/pyrad/issues/40)).
 
-This library **only supports** EAP-MSCHAPv2. This code has been tested with Microsoft Windows Server 2016 Network 
-Policy Server.
+This library **only supports** EAP-MSCHAPv2 and (legacy MSCHAPv2). This code has been tested with Microsoft Windows 
+Server 2016 Network Policy Server and FreeRADIUS 3.0.25.
 
 # Usage
 
@@ -22,6 +22,9 @@ username = 'myuser'
 password = 'mypassword!'
 
 r = RADIUS(radius_host, radius_secret, radius_nas_ip, radius_nas_id)
+
+# legacy MSCHAPv2 (no EAP)
+r = RADIUS(radius_host, radius_secret, radius_nas_ip, radius_nas_id, eap=False)
 print(r.is_credential_valid(username, password))</pre>
 
 

--- a/radius_eap_mschapv2/RADIUS.py
+++ b/radius_eap_mschapv2/RADIUS.py
@@ -679,3 +679,4 @@ class RADIUS:
             b += struct.pack('B', random.randint(0, 255))
 
         return b
+

--- a/radius_eap_mschapv2/RADIUS.py
+++ b/radius_eap_mschapv2/RADIUS.py
@@ -5,8 +5,8 @@ import random
 
 from Crypto.Hash import HMAC, MD5
 
-from .EAPPacket import EAPPacket
-from .MSCHAPv2 import MSCHAPv2Packet, MSCHAPv2Crypto, VendorSpecificPacket, MSCHAPv2Response
+from EAPPacket import EAPPacket
+from MSCHAPv2 import MSCHAPv2Packet, MSCHAPv2Crypto, VendorSpecificPacket, MSCHAPv2Response
 
 
 class RADIUSPacket:
@@ -524,8 +524,8 @@ class RADIUS:
             state = response_packet.get_raw_attribute(24)
             packet_to_send = RADIUSPacket(RADIUSPacket.TYPE_ACCESS_REQUEST, self.authenticator)
             packet_to_send.set_attribute(1, username)
-            packet_to_send.set_attribute(79, EAPPacket.legacyNak(response_eap.id))
             packet_to_send.set_raw_attribute(24, state)
+            packet_to_send.set_attribute(79, EAPPacket.legacyNak(response_eap.id))
             packet_to_send.set_include_message_authenticator()
             
             response_packet = self._send_and_read(packet_to_send)
@@ -534,10 +534,10 @@ class RADIUS:
 
             response_eap = EAPPacket.from_bytes(response_packet.get_raw_attribute(79)[2:])
             if response_eap.code != EAPPacket.CODE_REQUEST:
-                raise ValueError('Stage 1b : the server doesn\'t respond as expected')
+                raise ValueError('Stage 1 : the server doesn\'t respond as expected')
 
         if response_eap.type != EAPPacket.TYPE_EAP_MS_AUTH:
-            raise ValueError('Stage 1b : the server doesn\'t respond as expected')
+            raise ValueError('Stage 1 : the server doesn\'t respond as expected')
 
         response_eap_mschap2 = MSCHAPv2Packet.from_bytes(response_eap.data)
 


### PR DESCRIPTION
This PR adds support to authenticate with the legacy (non-EAP) version of MSCHAPv2.
Which is done by passing `eap=False` to `RADIUS()`.

The rest happens under the covers, making `is_credential_valid` call the new `_access_request_mschapv2` function (instead of `_access_request_eap_mschapv2`). Which in turn sends a request with `VendorSpecificPacket`'s containing a challenge and challenge `MSCHAPv2Response`.

This has been tested agains FreeRADIUS (same for EAP), the `README` has been updated to reflect that, and the new functionality.